### PR TITLE
add localstorage capability

### DIFF
--- a/docs/dist/grade.js
+++ b/docs/dist/grade.js
@@ -119,8 +119,23 @@ var Grade = function () {
     }, {
         key: 'renderGradient',
         value: function renderGradient() {
-            var chunked = this.getChunkedImageData();
-            var gradientProperty = this.getCSSGradientProperty(this.getTopValues(this.getUniqValues(chunked)));
+            var ls = window.localStorage;
+            var item_name = 'grade-' + this.image.getAttribute('src').split('/').slice(-1)[0];
+            var top = null;
+
+            if (ls && ls.getItem(item_name)) {
+                top = JSON.parse(ls.getItem(item_name));
+            } else {
+                var chunked = this.getChunkedImageData();
+                top = this.getTopValues(this.getUniqValues(chunked));
+
+                if (ls) {
+                    ls.setItem(item_name, JSON.stringify(top));
+                }
+            }
+
+            var gradientProperty = this.getCSSGradientProperty(top);
+
             var style = (this.container.getAttribute('style') || '') + '; ' + gradientProperty;
             this.container.setAttribute('style', style);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -100,8 +100,23 @@ class Grade {
     }
 
     renderGradient() {
-        let chunked = this.getChunkedImageData();
-        let gradientProperty = this.getCSSGradientProperty(this.getTopValues(this.getUniqValues(chunked)));
+        const ls = window.localStorage;
+        const item_name = `grade-${this.image.getAttribute('src').split('/').slice(-1)[0]}`;
+        let top = null;
+
+        if (ls && ls.getItem(item_name)) {
+            top = JSON.parse(ls.getItem(item_name));
+        } else {
+            let chunked = this.getChunkedImageData();
+            top = this.getTopValues(this.getUniqValues(chunked));
+
+            if (ls) {
+                ls.setItem(item_name, JSON.stringify(top));
+            }
+        }
+
+        let gradientProperty = this.getCSSGradientProperty(top);
+
         let style = `${this.container.getAttribute('style') || ''}; ${gradientProperty}`;
         this.container.setAttribute('style', style)
     }


### PR DESCRIPTION
This pull request aims to cache the calculated color values with `localStorage` to skip processing on subsequent requests. This might also avoid flash of unstyled div mentioned in #8 **after**  they have loaded initially.
