### PR TITLE
Update shadow to make it more subtle yet convey the same depth

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
         }
 
         .gradient-wrap img {
-            box-shadow: 0 1px 2px rgba(5,30,50,.6);
+            box-shadow: 0 10px 20px rgba(5,30,50,.1);
         }
     </style>
 </head>


### PR DESCRIPTION
Right now, the shadow used in the designs is very heavy on lighter gradients. By increasing the size and blur of the shadow and reducing the opacity to 10%, it provides the same effect and depth, without the darker shadow.
